### PR TITLE
Fix loading of iOS 4 device playlists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # iPod manager for foobar2000 changelog
 
-## 0.7.1 beta
+## 0.7.2
+
+* Fixed a possible 'Unsupported file format' error on iOS 4 devices when playlists have been modified on the device
+* Added support for playlist changes made on the device on iOS 4 devices
+
+## 0.7.1
 
 * Added play count, skip count, last played and last skipped columns to Manage contents
 * Attempted to improve reliability when used with some shuffle 4G models

--- a/foo_dop/api.cpp
+++ b/foo_dop/api.cpp
@@ -1,7 +1,7 @@
 #include "stdafx.h"
 
 // Fourth component of version no longer used
-dop::ipod_manager_control_t::version_data_t g_version = {0, 7, 1, 0};
+dop::ipod_manager_control_t::version_data_t g_version = {0, 7, 2, 0};
 
 /** Declare some information about our component */
 DECLARE_COMPONENT_VERSION_COPY("iPod manager",


### PR DESCRIPTION
This fixes a few problems related to the loading of on-the-go playlists on iOS 4 devices.

(The main problem was that they don't contain the `dbTimestampMacOsDate` property that nano 7G on-the-go playlists have.)

It also changes the logic so that if an on-the-go playlist cannot be loaded, a warning is logged to the console rather than aborting the entire load of the device's database.